### PR TITLE
Update WatchmanMonitoring-Status.xml

### DIFF
--- a/ExtensionAttributes/WatchmanMonitoring-Status.xml
+++ b/ExtensionAttributes/WatchmanMonitoring-Status.xml
@@ -3,18 +3,16 @@
 <displayName>Watchman Monitoring Status</displayName>
 <description>This attribute returns "Has issue" when Watchman Monitoring is reporting an error.</description>
 <dataType>string</dataType>
-<scriptContentsMac>#!/bin/sh&#13;
-&#13;
-if [ -f /Library/MonitoringClient/Utilities/ExportStatus ]; then&#13;
-if [ defaults read /Library/MonitoringClient/ClientData/UnifiedStatus.plist CurrentWarning ]; then&#13;
-   result="Has issue"&#13;
-else&#13;
-   result="No problems detected"&#13;
-fi&#13;
-echo "&lt;result&gt;$result&lt;/result&gt;"&#13;
-fi&#13;
-  echo "&lt;result&gt;Watchman Monitoring not installed&lt;/result&gt;"&#13;
-fi&#13;
+<scriptContentsMac>
+#!/bin/sh
+warning=`defaults read /Library/MonitoringClient/ClientData/UnifiedStatus CurrentWarning`
+if [ -f /Library/MonitoringClient/Utilities/ExportStatus ]; then
+	if [ "$warning" ];
+		then echo "<result>Has issue</result>";
+		else echo "<result>No problems detected</result>";
+	fi
+else echo "<result>Watchman Monitoring not installed</result>"
+fi
 </scriptContentsMac>
 <scriptContentsWindows/>
 </extensionAttribute>


### PR DESCRIPTION
Bash doesn't know boolean variables, nor does test (which is what gets called when you use []). This option is better to properly evaluate an computer warning state, to report with the extension attribute.
