### PR TITLE
Fix evaluation of command outputs

### DIFF
--- a/ExtensionAttributes/WatchmanMonitoring-Status.xml
+++ b/ExtensionAttributes/WatchmanMonitoring-Status.xml
@@ -3,18 +3,14 @@
 <displayName>Watchman Monitoring Status</displayName>
 <description>This attribute returns "Has issue" when Watchman Monitoring is reporting an error.</description>
 <dataType>string</dataType>
-<scriptContentsMac>#!/bin/sh&#13;
-&#13;
+<scriptContentsMac>#!/bin/bash&#13;
+warning=`defaults read /Library/MonitoringClient/ClientData/UnifiedStatus CurrentWarning`&#13;
 if [ -f /Library/MonitoringClient/Utilities/ExportStatus ]; then&#13;
-if [ defaults read /Library/MonitoringClient/ClientData/UnifiedStatus.plist CurrentWarning ]; then&#13;
-   result="Has issue"&#13;
-else&#13;
-   result="No problems detected"&#13;
-fi&#13;
-echo "&lt;result&gt;$result&lt;/result&gt;"&#13;
-fi&#13;
-  echo "&lt;result&gt;Watchman Monitoring not installed&lt;/result&gt;"&#13;
-fi&#13;
-</scriptContentsMac>
+	if [ "$warning" ];&#13;
+		then echo "&lt;result&gt;Has issue&lt;/result&gt;";&#13;
+		else echo "&lt;result&gt;No problems detected&lt;/result&gt;";&#13;
+	fi&#13;
+else echo "&lt;result&gt;Watchman Monitoring not installed&lt;/result&gt;"&#13;
+fi</scriptContentsMac>
 <scriptContentsWindows/>
 </extensionAttribute>


### PR DESCRIPTION
Bash doesn't know boolean variables, nor does test (which is what gets called when you use [ ]). This edit returns values that can be properly evaluated.
