### PR TITLE
Master

### DIFF
--- a/ExtensionAttributes/WatchmanMonitoring-ComputerURL.xml
+++ b/ExtensionAttributes/WatchmanMonitoring-ComputerURL.xml
@@ -1,11 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<extensionAttribute>
+<?xml version="1.0" encoding="UTF-8"?><extensionAttribute>
 <displayName>Watchman Monitoring Computer URL</displayName>
 <description>Displays the URL to a monitored computer's record in Watchman Monitoring.</description>
 <dataType>string</dataType>
-<scriptContentsMac>#!/bin/sh&#13;
-if [ -f /Library/MonitoringClient/Utilities/ExportStatus ]; then&#13;
-   echo "&lt;result&gt;`defaults read /Library/MonitoringClient/ClientData/UnifiedStatus.plist ClientURL`&lt;/result&gt;"&#13;
+<scriptContentsMac>#!/bin/bash&#13;
+if [[ -f /Library/MonitoringClient/Utilities/ExportStatus ]]; then&#13;
+   echo "&lt;result&gt;$(defaults read /Library/MonitoringClient/ClientData/UnifiedStatus.plist ClientURL)&lt;/result&gt;"&#13;
 else&#13;
   echo "&lt;result&gt;Watchman Monitoring not installed&lt;/result&gt;"&#13;
 fi</scriptContentsMac>

--- a/ExtensionAttributes/WatchmanMonitoring-Status.xml
+++ b/ExtensionAttributes/WatchmanMonitoring-Status.xml
@@ -1,20 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<extensionAttribute>
+<?xml version="1.0" encoding="UTF-8"?><extensionAttribute>
 <displayName>Watchman Monitoring Status</displayName>
 <description>This attribute returns "Has issue" when Watchman Monitoring is reporting an error.</description>
 <dataType>string</dataType>
-<scriptContentsMac>#!/bin/sh&#13;
+<scriptContentsMac>#!/bin/bash&#13;
 &#13;
-if [ -f /Library/MonitoringClient/Utilities/ExportStatus ]; then&#13;
-if [ defaults read /Library/MonitoringClient/ClientData/UnifiedStatus.plist CurrentWarning ]; then&#13;
-   result="Has issue"&#13;
+if [[ -f /Library/MonitoringClient/Utilities/ExportStatus ]]; then&#13;
+	if [[ $(defaults read /Library/MonitoringClient/ClientData/UnifiedStatus.plist CurrentWarning) -gt 0 ]]; then&#13;
+  	 	result="Has issue"&#13;
+	else&#13;
+   		result="No problems detected"&#13;
+	fi&#13;
+	echo "&lt;result&gt;$result&lt;/result&gt;"&#13;
 else&#13;
-   result="No problems detected"&#13;
-fi&#13;
-echo "&lt;result&gt;$result&lt;/result&gt;"&#13;
-fi&#13;
-  echo "&lt;result&gt;Watchman Monitoring not installed&lt;/result&gt;"&#13;
-fi&#13;
-</scriptContentsMac>
+	echo "&lt;result&gt;Watchman Monitoring not installed&lt;/result&gt;"&#13;
+fi</scriptContentsMac>
 <scriptContentsWindows/>
 </extensionAttribute>

--- a/ExtensionAttributes/WatchmanPluginList-Long.xml
+++ b/ExtensionAttributes/WatchmanPluginList-Long.xml
@@ -1,11 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<extensionAttribute>
+<?xml version="1.0" encoding="UTF-8"?><extensionAttribute>
 <displayName>Watchman Monitoring-Full Report</displayName>
 <description>Displays a list of all plugins active on the computer, and their status.</description>
 <dataType>string</dataType>
-<scriptContentsMac>#!/bin/sh&#13;
-if [ -f /Library/MonitoringClient/Utilities/ExportStatus ]; then&#13;
-   echo "&lt;result&gt;`/Library/MonitoringClient/Utilities/ExportStatus -v`&lt;/result&gt;"&#13;
+<scriptContentsMac>#!/bin/bash&#13;
+if [[ -f /Library/MonitoringClient/Utilities/ExportStatus ]]; then&#13;
+   echo "&lt;result&gt;$(/Library/MonitoringClient/Utilities/ExportStatus -v)&lt;/result&gt;"&#13;
 else&#13;
   echo "&lt;result&gt;Watchman Monitoring not installed&lt;/result&gt;"&#13;
 fi</scriptContentsMac>


### PR DESCRIPTION
1) Watchman Monitoring Status Extension Attribute contained syntax errors with the if statements and flow control, this created incorrect results reported back to the Jamf Pro MDM, this has been repaired.
2) Updated scripts to follow contemporary bash scripting standards.